### PR TITLE
Fix training step calculation

### DIFF
--- a/lightning_transformers/core/model.py
+++ b/lightning_transformers/core/model.py
@@ -27,11 +27,7 @@ class LitTransformer(pl.LightningModule):
         """Prepare optimizer and scheduler"""
         return {
             "optimizer": self.optimizer,
-            "lr_scheduler": {
-                "scheduler": self.scheduler,
-                "interval": "step",
-                "frequency": 1,
-            },
+            "lr_scheduler": {"scheduler": self.scheduler, "interval": "step", "frequency": 1},
         }
 
     @property
@@ -40,10 +36,7 @@ class LitTransformer(pl.LightningModule):
         if self.trainer.max_steps:
             return self.trainer.max_steps
 
-        if (
-            isinstance(self.trainer.limit_train_batches, int)
-            and self.trainer.limit_train_batches != 0
-        ):
+        if isinstance(self.trainer.limit_train_batches, int) and self.trainer.limit_train_batches != 0:
             dataset_size = self.trainer.limit_train_batches
         elif isinstance(self.trainer.limit_train_batches, float):
             # limit_train_batches is a percentage of batches
@@ -56,11 +49,7 @@ class LitTransformer(pl.LightningModule):
         if self.trainer.tpu_cores:
             num_devices = max(num_devices, self.trainer.tpu_cores)
 
-        effective_batch_size = (
-            self.trainer.datamodule.batch_size
-            * self.trainer.accumulate_grad_batches
-            * num_devices
-        )
+        effective_batch_size = self.trainer.datamodule.batch_size * self.trainer.accumulate_grad_batches * num_devices
         return (dataset_size // effective_batch_size) * self.trainer.max_epochs
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+line_length = 120
+force_sort_within_sections = "False"
+order_by_type = "False"

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,12 +29,6 @@ ignore =
     E231  # missing whitespace after ',', ';', or ':'; for black
     W503  # line break before binary operator, need for black
 
-[isort]
-profile = black
-line_length = 120
-force_sort_within_sections = False
-order_by_type = False
-
 # setup.cfg or tox.ini
 [check-manifest]
 ignore =


### PR DESCRIPTION
We were missing the float (default) `limit_train_batches` option hence our calculation was wrong (defaulted to 0)