### PR TITLE
Reduce max epochs to 1

### DIFF
--- a/conf/trainer/default.yaml
+++ b/conf/trainer/default.yaml
@@ -17,7 +17,7 @@ track_grad_norm: -1
 check_val_every_n_epoch: 1
 fast_dev_run: False
 accumulate_grad_batches: 1
-max_epochs: 1000
+max_epochs: 1
 min_epochs: 1
 max_steps: null
 min_steps: null


### PR DESCRIPTION
In most cases we're using a pre-trained model, so let's drop the default from 1000...