### PR TITLE
Fix training step calculation (remove already applied batch size)

### DIFF
--- a/lightning_transformers/core/model.py
+++ b/lightning_transformers/core/model.py
@@ -49,7 +49,7 @@ class LitTransformer(pl.LightningModule):
         if self.trainer.tpu_cores:
             num_devices = max(num_devices, self.trainer.tpu_cores)
 
-        effective_batch_size = self.trainer.datamodule.batch_size * self.trainer.accumulate_grad_batches * num_devices
+        effective_batch_size = self.trainer.accumulate_grad_batches * num_devices
         return (dataset_size // effective_batch_size) * self.trainer.max_epochs
 
 


### PR DESCRIPTION
Remove batch size from effective batch size calculation because it's already been applied via the data-loader.

I noticed this issue when experimenting and trying to get text-classification together. This fixed the issue because the data-loader already takes into account the actual batch size!

