### PR TITLE
Add benchmark callback, update confs

### DIFF
--- a/conf/trainer/benchmark.yaml
+++ b/conf/trainer/benchmark.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - default # add args from default trainer conf
+gpus: 1
+accelerator: ddp
+precision: 16
+amp_backend: 'native'
+checkpoint_callback: False
+limit_val_batches: 0
+limit_test_batches: 0
+callbacks:
+  _target_: lightning_transformers.core.callback.CUDACallback

--- a/conf/trainer/sharded.yaml
+++ b/conf/trainer/sharded.yaml
@@ -3,4 +3,5 @@ defaults:
 gpus: 2
 accelerator: ddp
 plugins: "ddp_sharded"
+precision: 16
 amp_backend: 'native'

--- a/lightning_transformers/core/callback.py
+++ b/lightning_transformers/core/callback.py
@@ -1,0 +1,25 @@
+import time
+
+import torch
+from pytorch_lightning import Callback
+from pytorch_lightning.utilities import rank_zero_info
+
+
+class CUDACallback(Callback):
+
+    def on_train_epoch_start(self, trainer, pl_module):
+        # Reset the memory use counter
+        torch.cuda.reset_peak_memory_stats(trainer.root_gpu)
+        torch.cuda.synchronize(trainer.root_gpu)
+        self.start_time = time.time()
+
+    def on_train_epoch_end(self, trainer, pl_module, outputs):
+        torch.cuda.synchronize(trainer.root_gpu)
+        max_memory = torch.cuda.max_memory_allocated(trainer.root_gpu) / 2**20
+        epoch_time = time.time() - self.start_time
+
+        max_memory = trainer.training_type_plugin.reduce(max_memory)
+        epoch_time = trainer.training_type_plugin.reduce(epoch_time)
+
+        rank_zero_info(f"Average Epoch time: {epoch_time:.2f} seconds")
+        rank_zero_info(f"Average Peak memory {max_memory:.2f}MiB")


### PR DESCRIPTION
Adds a benchmark trainer script which is useful for benchmarking models. We've copied the same callback in a few places, will probably need to upstream to lightning